### PR TITLE
Rename to app.py and fix python3 syntax errors

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-from BaseHTTPServer import BaseHTTPRequestHandler,HTTPServer
+from http.server import BaseHTTPRequestHandler,HTTPServer
 from os import curdir,sep
 
 PORT_NUMBER = 8080
@@ -17,7 +17,7 @@ class myHandler(BaseHTTPRequestHandler):
 
 try:
 	server = HTTPServer(('', PORT_NUMBER), myHandler)
-	print 'Started httpserver on port ' , PORT_NUMBER
+	print('Started httpserver on port ' , PORT_NUMBER)
 	server.serve_forever()
 
 except KeyboardInterrupt:


### PR DESCRIPTION
The Dockerfile is looking for a script called app.py to build, so it doesn't recognize http-server.py.  Also, since we're building for Python 3, the BaseHttpServer module was moved to http.server and print statements now require parentheses.  These changes are necessary for project to build successfully.